### PR TITLE
Rakefile vs Makefile evaluation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rake", "~> 13.2"
+gem "rake", "~> 13.3"
 gem "jekyll", "~> 4.4"
 
 group :jekyll_plugins do

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "rake", "~> 13.2"
 gem "jekyll", "~> 4.4"
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ DEPENDENCIES
   jekyll-paginate
   jekyll-sitemap
   jekyll_picture_tag (~> 2.0)
+  rake (~> 13.3)
   webrick (~> 1.9)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -60,15 +60,12 @@ Set your Listmonk config via environment variables:
 - **`LISTMONK_USER` / `LISTMONK_TOKEN`**: Listmonk API user + token (sent as Basic auth `user:token`)
   - Set **`LISTMONK_AUTH_MODE=header`** to send `Authorization: token user:token` instead.
 
-Legacy/backcompat (if you used it previously):
-
-- **`LISTMONK_PASSWORD`**: Basic auth password (only used if `LISTMONK_TOKEN` is not set)
-
 Optional:
 
 - **`LISTMONK_SUBJECT`**: Email subject (defaults to the post title)
-- **`LISTMONK_CAMPAIGN_NAME`**: Campaign name (defaults to `"Newsletter: <title>"`)
+- **`LISTMONK_CAMPAIGN_NAME`**: Campaign name (defaults to the post title)
 - **`LISTMONK_CAMPAIGN_TYPE`**: Defaults to `regular`
+- **`LISTMONK_TEMPLATE_ID`**: Campaign template ID
 - **`LISTMONK_FROM_EMAIL` / `LISTMONK_FROM_NAME`**
 - **`LISTMONK_TAGS`**: Comma-separated tags
 - **`DRY_RUN=1`**: Print HTML and skip API calls

--- a/README.md
+++ b/README.md
@@ -57,8 +57,12 @@ Set your Listmonk config via environment variables:
 
 - **`LISTMONK_URL`**: Base URL, e.g. `https://list.example.com`
 - **`LISTMONK_LIST_IDS`**: Comma-separated list IDs, e.g. `1,2`
-- **`LISTMONK_USER` / `LISTMONK_PASSWORD`**: Admin API credentials (Basic auth)
-  - Alternatively **`LISTMONK_TOKEN`** (Bearer token), if your Listmonk setup supports it
+- **`LISTMONK_USER` / `LISTMONK_TOKEN`**: Listmonk API user + token (sent as Basic auth `user:token`)
+  - Set **`LISTMONK_AUTH_MODE=header`** to send `Authorization: token user:token` instead.
+
+Legacy/backcompat (if you used it previously):
+
+- **`LISTMONK_PASSWORD`**: Basic auth password (only used if `LISTMONK_TOKEN` is not set)
 
 Optional:
 
@@ -74,7 +78,7 @@ Example:
 ```sh
 LISTMONK_URL="https://list.example.com" \
 LISTMONK_USER="admin" \
-LISTMONK_PASSWORD="secret" \
+LISTMONK_TOKEN="token" \
 LISTMONK_LIST_IDS="1" \
 bundle exec rake newsletter:campaign[2024-03-07-instructions-beyond-code]
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,45 @@ Note:
 make deploy DEPLOY_TARGET="user@example.org:/path/to/webroot"
 ```
 
+## Newsletter automation (Listmonk)
+
+This repo includes a `Rakefile` that can render a Jekyll post (including Liquid tags)
+into an email-friendly HTML fragment and create a Listmonk campaign from it.
+
+### Preview
+
+```sh
+bundle exec rake newsletter:preview[instructions-beyond-code]
+```
+
+### Create a campaign
+
+Set your Listmonk config via environment variables:
+
+- **`LISTMONK_URL`**: Base URL, e.g. `https://list.example.com`
+- **`LISTMONK_LIST_IDS`**: Comma-separated list IDs, e.g. `1,2`
+- **`LISTMONK_USER` / `LISTMONK_PASSWORD`**: Admin API credentials (Basic auth)
+  - Alternatively **`LISTMONK_TOKEN`** (Bearer token), if your Listmonk setup supports it
+
+Optional:
+
+- **`LISTMONK_SUBJECT`**: Email subject (defaults to the post title)
+- **`LISTMONK_CAMPAIGN_NAME`**: Campaign name (defaults to `"Newsletter: <title>"`)
+- **`LISTMONK_CAMPAIGN_TYPE`**: Defaults to `regular`
+- **`LISTMONK_FROM_EMAIL` / `LISTMONK_FROM_NAME`**
+- **`LISTMONK_TAGS`**: Comma-separated tags
+- **`DRY_RUN=1`**: Print HTML and skip API calls
+
+Example:
+
+```sh
+LISTMONK_URL="https://list.example.com" \
+LISTMONK_USER="admin" \
+LISTMONK_PASSWORD="secret" \
+LISTMONK_LIST_IDS="1" \
+bundle exec rake newsletter:campaign[2024-03-07-instructions-beyond-code]
+```
+
 ## Screenshot
 
 ![Screenshot](/assets/img/screenshot.png?raw=true)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,112 @@
+require "rake"
+
+require_relative "lib/newsletter/jekyll_post_renderer"
+require_relative "lib/newsletter/listmonk_client"
+
+namespace :newsletter do
+  desc "Preview the rendered email HTML for a post (DRY_RUN=1 is implied)"
+  task :preview, [:post] do |_, args|
+    post = args[:post].to_s
+    abort "Usage: bundle exec rake newsletter:preview[post-slug-or-path]" if post.empty?
+
+    rendered = Newsletter::JekyllPostRenderer.new.render_post_fragment!(post)
+    puts NewsletterEmail.compose(rendered)
+  end
+
+  desc "Create a Listmonk campaign from a Jekyll post (set LISTMONK_* env vars)"
+  task :campaign, [:post] do |_, args|
+    post = args[:post].to_s
+    abort "Usage: bundle exec rake newsletter:campaign[post-slug-or-path]" if post.empty?
+
+    rendered = Newsletter::JekyllPostRenderer.new.render_post_fragment!(post)
+    html_body = NewsletterEmail.compose(rendered)
+
+    if ENV["DRY_RUN"].to_s == "1"
+      puts html_body
+      warn "DRY_RUN=1 set, not calling Listmonk."
+      next
+    end
+
+    base_url = ENV.fetch("LISTMONK_URL")
+    username = ENV["LISTMONK_USER"]
+    password = ENV["LISTMONK_PASSWORD"]
+    token = ENV["LISTMONK_TOKEN"]
+
+    list_ids = ENV.fetch("LISTMONK_LIST_IDS").split(",").map(&:strip).reject(&:empty?).map(&:to_i)
+    raise "LISTMONK_LIST_IDS must contain at least one list id" if list_ids.empty?
+
+    name = ENV["LISTMONK_CAMPAIGN_NAME"].to_s
+    name = "Newsletter: #{rendered[:title]}" if name.empty?
+
+    subject = ENV["LISTMONK_SUBJECT"].to_s
+    subject = rendered[:title] if subject.empty?
+
+    type = ENV.fetch("LISTMONK_CAMPAIGN_TYPE", "regular")
+    from_email = ENV["LISTMONK_FROM_EMAIL"]
+    from_name = ENV["LISTMONK_FROM_NAME"]
+
+    tags = ENV["LISTMONK_TAGS"]&.split(",")&.map(&:strip)&.reject(&:empty?)
+
+    client = Newsletter::ListmonkClient.new(
+      base_url: base_url,
+      username: username,
+      password: password,
+      token: token
+    )
+
+    res = client.create_campaign!(
+      name: name,
+      subject: subject,
+      lists: list_ids,
+      html_body: html_body,
+      type: type,
+      from_email: from_email,
+      from_name: from_name,
+      tags: tags
+    )
+
+    id = res.dig("data", "id") || res["id"]
+    warn "Created Listmonk campaign id=#{id || "(unknown)"}"
+  end
+end
+
+# Email composition lives here for now; later you can extract into lib/.
+module NewsletterEmail
+  module_function
+
+  def compose(rendered)
+    title = rendered[:title].to_s
+    description = rendered[:description].to_s
+    url = rendered[:url].to_s
+    fragment = rendered[:html].to_s
+
+    fragment = strip_excerpt(fragment)
+
+    header_bits = []
+    header_bits << %(<h1 style="margin: 0 0 0.5em 0;">#{escape_html(title)}</h1>) unless title.empty?
+    header_bits << %(<p style="margin: 0 0 1em 0; opacity: 0.85;">#{escape_html(description)}</p>) unless description.empty?
+    header_bits << %(<p style="margin: 0 0 1.5em 0;"><a href="#{escape_attr(url)}">Read on the web</a></p>) unless url.empty?
+
+    (header_bits.join("\n") + "\n" + fragment).strip + "\n"
+  end
+
+  # Your site uses <!--more--> as excerpt_separator.
+  # If it survives into the rendered output, remove it for email.
+  def strip_excerpt(html)
+    html.to_s.gsub("<!--more-->", "")
+  end
+
+  def escape_html(s)
+    s.to_s
+      .gsub("&", "&amp;")
+      .gsub("<", "&lt;")
+      .gsub(">", "&gt;")
+      .gsub('"', "&quot;")
+      .gsub("'", "&#39;")
+  end
+
+  def escape_attr(s)
+    escape_html(s)
+  end
+end
+

--- a/Rakefile
+++ b/Rakefile
@@ -75,19 +75,10 @@ module NewsletterEmail
   module_function
 
   def compose(rendered)
-    title = rendered[:title].to_s
-    description = rendered[:description].to_s
-    url = rendered[:url].to_s
     fragment = rendered[:html].to_s
 
     fragment = strip_excerpt(fragment)
-
-    header_bits = []
-    header_bits << %(<h1 style="margin: 0 0 0.5em 0;">#{escape_html(title)}</h1>) unless title.empty?
-    header_bits << %(<p style="margin: 0 0 1em 0; opacity: 0.85;">#{escape_html(description)}</p>) unless description.empty?
-    header_bits << %(<p style="margin: 0 0 1.5em 0;"><a href="#{escape_attr(url)}">Read on the web</a></p>) unless url.empty?
-
-    (header_bits.join("\n") + "\n" + fragment).strip + "\n"
+    fragment.strip + "\n"
   end
 
   # Your site uses <!--more--> as excerpt_separator.
@@ -96,17 +87,5 @@ module NewsletterEmail
     html.to_s.gsub("<!--more-->", "")
   end
 
-  def escape_html(s)
-    s.to_s
-      .gsub("&", "&amp;")
-      .gsub("<", "&lt;")
-      .gsub(">", "&gt;")
-      .gsub('"', "&quot;")
-      .gsub("'", "&#39;")
-  end
-
-  def escape_attr(s)
-    escape_html(s)
-  end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,8 +29,10 @@ namespace :newsletter do
 
     base_url = ENV.fetch("LISTMONK_URL")
     username = ENV["LISTMONK_USER"]
-    password = ENV["LISTMONK_PASSWORD"]
     token = ENV["LISTMONK_TOKEN"]
+    password = ENV["LISTMONK_PASSWORD"] # legacy/backcompat
+
+    use_token_header = ENV.fetch("LISTMONK_AUTH_MODE", "").downcase == "header"
 
     list_ids = ENV.fetch("LISTMONK_LIST_IDS").split(",").map(&:strip).reject(&:empty?).map(&:to_i)
     raise "LISTMONK_LIST_IDS must contain at least one list id" if list_ids.empty?
@@ -51,7 +53,8 @@ namespace :newsletter do
       base_url: base_url,
       username: username,
       password: password,
-      token: token
+      token: token,
+      use_token_header: use_token_header
     )
 
     res = client.create_campaign!(

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,6 @@ namespace :newsletter do
     base_url = ENV.fetch("LISTMONK_URL")
     username = ENV["LISTMONK_USER"]
     token = ENV["LISTMONK_TOKEN"]
-    password = ENV["LISTMONK_PASSWORD"] # legacy/backcompat
 
     use_token_header = ENV.fetch("LISTMONK_AUTH_MODE", "").downcase == "header"
 
@@ -38,12 +37,14 @@ namespace :newsletter do
     raise "LISTMONK_LIST_IDS must contain at least one list id" if list_ids.empty?
 
     name = ENV["LISTMONK_CAMPAIGN_NAME"].to_s
-    name = "Newsletter: #{rendered[:title]}" if name.empty?
+    name = rendered[:title].to_s if name.empty?
 
     subject = ENV["LISTMONK_SUBJECT"].to_s
     subject = rendered[:title] if subject.empty?
 
     type = ENV.fetch("LISTMONK_CAMPAIGN_TYPE", "regular")
+    template_id = ENV["LISTMONK_TEMPLATE_ID"]&.to_s&.strip
+    template_id = template_id.to_i if template_id && !template_id.empty?
     from_email = ENV["LISTMONK_FROM_EMAIL"]
     from_name = ENV["LISTMONK_FROM_NAME"]
 
@@ -52,7 +53,6 @@ namespace :newsletter do
     client = Newsletter::ListmonkClient.new(
       base_url: base_url,
       username: username,
-      password: password,
       token: token,
       use_token_header: use_token_header
     )
@@ -63,6 +63,7 @@ namespace :newsletter do
       lists: list_ids,
       html_body: html_body,
       type: type,
+      template_id: template_id,
       from_email: from_email,
       from_name: from_name,
       tags: tags

--- a/_config.yml
+++ b/_config.yml
@@ -88,7 +88,9 @@ exclude:
   - LICENSE
   - README.md
   - Makefile
+  - Rakefile
   - package-lock.json
   - package.json
   - screenshot.png
+  - lib
   - vendor

--- a/_data/picture.yml
+++ b/_data/picture.yml
@@ -9,6 +9,12 @@ presets:
     fallback_width: 800
     markup: img
 
+  newsletter:
+    formats: [jpg]
+    widths: [640]
+    fallback_width: 640
+    markup: img
+
   meta:
     formats: [jpg]
     fallback_width: 1280

--- a/jekyll_listmonk/Gemfile
+++ b/jekyll_listmonk/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "rake", "~> 13.3"
+

--- a/jekyll_listmonk/LICENSE.txt
+++ b/jekyll_listmonk/LICENSE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/jekyll_listmonk/README.md
+++ b/jekyll_listmonk/README.md
@@ -1,0 +1,71 @@
+# jekyll_listmonk
+
+Create listmonk campaigns from Jekyll posts.
+
+This is designed to run **inside a target Jekyll site's Bundler environment** so the
+site's plugins (for example `jekyll_picture_tag`) are available.
+
+## Install (in a target Jekyll repo)
+
+Add to the site's `Gemfile`:
+
+```ruby
+group :development do
+  gem "jekyll_listmonk", path: "../jekyll_listmonk"
+end
+```
+
+Then:
+
+```sh
+bundle install
+```
+
+## Usage
+
+Preview rendered HTML:
+
+```sh
+bundle exec jekyll-listmonk preview 2025-12-19-white-fungus-issue-18-dino
+```
+
+Create a campaign:
+
+```sh
+LISTMONK_URL="https://list.example.com" \
+LISTMONK_USER="api_user" \
+LISTMONK_TOKEN="api_token" \
+LISTMONK_LIST_IDS="1" \
+bundle exec jekyll-listmonk campaign 2025-12-19-white-fungus-issue-18-dino
+```
+
+### Environment variables
+
+Required:
+
+- `LISTMONK_URL`
+- `LISTMONK_USER`
+- `LISTMONK_TOKEN`
+- `LISTMONK_LIST_IDS` (comma-separated)
+
+Optional:
+
+- `LISTMONK_AUTH_MODE=header` (send `Authorization: token user:token` instead of Basic auth)
+- `LISTMONK_TEMPLATE_ID`
+- `LISTMONK_SUBJECT` (defaults to post title)
+- `LISTMONK_CAMPAIGN_NAME` (defaults to post title)
+- `LISTMONK_CAMPAIGN_TYPE` (defaults to `regular`)
+- `LISTMONK_FROM_EMAIL`, `LISTMONK_FROM_NAME`
+- `LISTMONK_TAGS` (comma-separated)
+- `DRY_RUN=1` (prints HTML and does not call the API)
+
+## Image behavior
+
+- If a post's front matter has an `image` field, a `{% picture ... %}` tag is injected as
+  the first line of content.
+- In-body `{% picture ... %}` tags are rewritten to use the `newsletter` preset and have
+  `--img class="..."` removed.
+- Any resulting `srcset`/`sizes` attributes are stripped from `<img>` tags in the output.
+
+This expects the target site to define a `newsletter` preset in `_data/picture.yml`.
+

--- a/jekyll_listmonk/exe/jekyll-listmonk
+++ b/jekyll_listmonk/exe/jekyll-listmonk
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require "jekyll_listmonk"
+
+exit(JekyllListmonk::CLI.run(ARGV))
+

--- a/jekyll_listmonk/jekyll_listmonk.gemspec
+++ b/jekyll_listmonk/jekyll_listmonk.gemspec
@@ -1,0 +1,28 @@
+Gem::Specification.new do |spec|
+  spec.name = "jekyll_listmonk"
+  spec.version = "0.1.0"
+  spec.authors = ["Christopher Adams"]
+  spec.email = ["info@christopheradams.io"]
+
+  spec.summary = "Create listmonk campaigns from Jekyll posts."
+  spec.description = "A small CLI that renders a Jekyll post (Liquid + Markdown) and creates a listmonk campaign."
+  spec.homepage = "https://github.com/yourname/jekyll_listmonk"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.0"
+
+  spec.files = Dir[
+    "lib/**/*.rb",
+    "exe/*",
+    "README.md",
+    "LICENSE.txt"
+  ]
+
+  spec.bindir = "exe"
+  spec.executables = ["jekyll-listmonk"]
+  spec.require_paths = ["lib"]
+
+  # Jekyll is required at runtime; this tool is intended to be run inside a target
+  # Jekyll site's Bundler environment so the site's plugins are available too.
+  spec.add_dependency "jekyll", ">= 4.0", "< 5.0"
+end
+

--- a/jekyll_listmonk/lib/jekyll_listmonk.rb
+++ b/jekyll_listmonk/lib/jekyll_listmonk.rb
@@ -1,0 +1,9 @@
+require_relative "jekyll_listmonk/version"
+require_relative "jekyll_listmonk/cli"
+require_relative "jekyll_listmonk/jekyll_post_renderer"
+require_relative "jekyll_listmonk/listmonk_client"
+require_relative "jekyll_listmonk/picture_tag_rewriter"
+
+module JekyllListmonk
+end
+

--- a/jekyll_listmonk/lib/jekyll_listmonk/cli.rb
+++ b/jekyll_listmonk/lib/jekyll_listmonk/cli.rb
@@ -1,0 +1,89 @@
+require "optparse"
+
+module JekyllListmonk
+  class CLI
+    def self.run(argv)
+      new(argv).run
+    rescue Interrupt
+      warn "Interrupted."
+      130
+    rescue StandardError => e
+      warn "Error: #{e.message}"
+      1
+    end
+
+    def initialize(argv)
+      @argv = argv.dup
+      @source = Dir.pwd
+    end
+
+    def run
+      global = OptionParser.new do |o|
+        o.banner = "Usage: jekyll-listmonk [--source PATH] <command> <post-id>\n\nCommands: preview, campaign"
+        o.on("--source PATH", "Jekyll site path (default: current directory)") { |v| @source = v }
+        o.on("-h", "--help", "Show help") { puts o; return 0 }
+      end
+      global.order!(@argv)
+
+      cmd = @argv.shift
+      post = @argv.shift
+      raise "Missing command (preview|campaign)" if cmd.nil? || cmd.empty?
+      raise "Missing post identifier" if post.nil? || post.empty?
+
+      renderer = JekyllPostRenderer.new(source_dir: @source)
+      rendered = renderer.render_post_fragment!(post)
+      html = rendered[:html].to_s
+
+      case cmd
+      when "preview"
+        puts html
+        0
+      when "campaign"
+        if ENV["DRY_RUN"].to_s == "1"
+          puts html
+          warn "DRY_RUN=1 set, not calling Listmonk."
+          return 0
+        end
+
+        client = ListmonkClient.from_env
+
+        name = ENV["LISTMONK_CAMPAIGN_NAME"].to_s
+        name = rendered[:title].to_s if name.empty?
+
+        subject = ENV["LISTMONK_SUBJECT"].to_s
+        subject = rendered[:title].to_s if subject.empty?
+
+        list_ids = ENV.fetch("LISTMONK_LIST_IDS").split(",").map(&:strip).reject(&:empty?).map(&:to_i)
+        raise "LISTMONK_LIST_IDS must contain at least one list id" if list_ids.empty?
+
+        type = ENV.fetch("LISTMONK_CAMPAIGN_TYPE", "regular")
+
+        template_id = ENV["LISTMONK_TEMPLATE_ID"]&.to_s&.strip
+        template_id = template_id.to_i if template_id && !template_id.empty?
+
+        from_email = ENV["LISTMONK_FROM_EMAIL"]
+        from_name = ENV["LISTMONK_FROM_NAME"]
+        tags = ENV["LISTMONK_TAGS"]&.split(",")&.map(&:strip)&.reject(&:empty?)
+
+        res = client.create_campaign!(
+          name: name,
+          subject: subject,
+          lists: list_ids,
+          html_body: html,
+          type: type,
+          template_id: template_id,
+          from_email: from_email,
+          from_name: from_name,
+          tags: tags
+        )
+
+        id = res.dig("data", "id") || res["id"]
+        warn "Created Listmonk campaign id=#{id || "(unknown)"}"
+        0
+      else
+        raise "Unknown command: #{cmd.inspect} (expected preview|campaign)"
+      end
+    end
+  end
+end
+

--- a/jekyll_listmonk/lib/jekyll_listmonk/jekyll_post_renderer.rb
+++ b/jekyll_listmonk/lib/jekyll_listmonk/jekyll_post_renderer.rb
@@ -1,0 +1,75 @@
+module JekyllListmonk
+  class JekyllPostRenderer
+    class Error < StandardError; end
+
+    def initialize(source_dir: Dir.pwd, jekyll_env: ENV.fetch("JEKYLL_ENV", "production"))
+      @source_dir = source_dir
+      @jekyll_env = jekyll_env
+      @rewriter = PictureTagRewriter.new
+    end
+
+    # identifier can be:
+    # - a slug like "instructions-beyond-code"
+    # - a post filename stem like "2024-03-07-instructions-beyond-code"
+    # - a path like "_posts/2024-03-07-instructions-beyond-code.md"
+    def render_post_fragment!(identifier)
+      require "jekyll"
+
+      ENV["JEKYLL_ENV"] = @jekyll_env
+
+      site = Jekyll::Site.new(Jekyll.configuration({ "source" => @source_dir, "quiet" => true }))
+      site.reset
+      site.read
+
+      doc = resolve_post!(site, identifier)
+
+      original_layout = doc.data["layout"]
+      original_content = doc.content
+
+      doc.data["layout"] = nil
+      doc.content = @rewriter.rewrite(original_content, frontmatter_image: doc.data["image"])
+
+      renderer = Jekyll::Renderer.new(site, doc)
+      html = renderer.run.to_s
+      html = @rewriter.strip_responsive_img_attributes(html)
+
+      doc.data["layout"] = original_layout
+      doc.content = original_content
+
+      { title: doc.data["title"].to_s, html: html }
+    rescue LoadError => e
+      raise Error, "Jekyll not available: #{e.message}. Run inside a Jekyll repo with Bundler (bundle exec ...)."
+    end
+
+    private
+
+    def resolve_post!(site, identifier)
+      id = identifier.to_s.strip
+      raise Error, "Missing post identifier" if id.empty?
+
+      candidates = site.posts.docs
+
+      if id.include?("/") || id.end_with?(".md", ".markdown")
+        normalized = id.sub(%r{\A\./}, "")
+        match = candidates.find { |d| d.relative_path == normalized || d.path.end_with?(normalized) }
+        return match if match
+        raise Error, "No post matched path #{identifier.inspect}"
+      end
+
+      matches = candidates.select do |d|
+        stem = File.basename(d.path, ".*")
+        slug = stem.sub(/^\d{4}-\d{2}-\d{2}-/, "")
+        dslug = d.data["slug"].to_s
+
+        id == stem || id == slug || (!dslug.empty? && id == dslug) || stem.include?(id)
+      end
+
+      return matches.first if matches.size == 1
+      raise Error, "No post matched #{identifier.inspect}" if matches.empty?
+
+      raise Error,
+            "Ambiguous identifier #{identifier.inspect}. Matches: #{matches.map { |d| d.relative_path }.join(', ')}"
+    end
+  end
+end
+

--- a/jekyll_listmonk/lib/jekyll_listmonk/listmonk_client.rb
+++ b/jekyll_listmonk/lib/jekyll_listmonk/listmonk_client.rb
@@ -1,0 +1,96 @@
+require "json"
+require "net/http"
+require "uri"
+
+module JekyllListmonk
+  class ListmonkClient
+    class Error < StandardError; end
+
+    def self.from_env
+      base_url = ENV.fetch("LISTMONK_URL")
+      username = ENV.fetch("LISTMONK_USER")
+      token = ENV.fetch("LISTMONK_TOKEN")
+      use_token_header = ENV.fetch("LISTMONK_AUTH_MODE", "").downcase == "header"
+
+      new(base_url: base_url, username: username, token: token, use_token_header: use_token_header)
+    end
+
+    # Auth modes supported by listmonk:
+    # - Basic auth: username=api_user, token=api_token (sent as user:token)
+    # - Authorization header: "token api_user:api_token"
+    #
+    # This client supports both. By default, it uses Basic auth.
+    def initialize(base_url:, username:, token:, use_token_header: false, timeout: 30)
+      @base_uri = URI(base_url)
+      @username = username
+      @token = token
+      @use_token_header = use_token_header
+      @timeout = timeout
+    end
+
+    def create_campaign!(
+      name:,
+      subject:,
+      lists:,
+      html_body:,
+      type: "regular",
+      template_id: nil,
+      from_email: nil,
+      from_name: nil,
+      tags: nil
+    )
+      payload = {
+        name: name,
+        subject: subject,
+        lists: lists,
+        type: type,
+        content_type: "html",
+        body: html_body
+      }
+
+      payload[:template_id] = template_id if template_id
+      payload[:from_email] = from_email if from_email && !from_email.empty?
+      payload[:from_name] = from_name if from_name && !from_name.empty?
+      payload[:tags] = tags if tags && !tags.empty?
+
+      post_json!("/api/campaigns", payload)
+    end
+
+    private
+
+    def post_json!(path, payload)
+      uri = @base_uri.dup
+      uri.path = File.join(uri.path, path)
+
+      req = Net::HTTP::Post.new(uri)
+      req["Accept"] = "application/json"
+      req["Content-Type"] = "application/json"
+      req.body = JSON.dump(payload)
+
+      apply_auth!(req)
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == "https")
+      http.open_timeout = @timeout
+      http.read_timeout = @timeout
+
+      res = http.request(req)
+      body = res.body.to_s
+
+      raise Error, "Listmonk API error (HTTP #{res.code}): #{body}" unless res.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(body)
+    rescue JSON::ParserError
+      raise Error, "Listmonk API returned non-JSON response (HTTP #{res&.code}): #{body}"
+    end
+
+    def apply_auth!(req)
+      if @use_token_header
+        req["Authorization"] = "token #{@username}:#{@token}"
+      else
+        req.basic_auth(@username, @token)
+      end
+    end
+  end
+end
+

--- a/jekyll_listmonk/lib/jekyll_listmonk/picture_tag_rewriter.rb
+++ b/jekyll_listmonk/lib/jekyll_listmonk/picture_tag_rewriter.rb
@@ -1,0 +1,143 @@
+module JekyllListmonk
+  class PictureTagRewriter
+    def initialize(preset: "newsletter")
+      @preset = preset
+    end
+
+    def rewrite(markdown, frontmatter_image:)
+      content = markdown.to_s
+      content = inject_frontmatter_image_picture_tag(content, frontmatter_image)
+      rewrite_picture_tags_for_newsletter(content)
+    end
+
+    def strip_responsive_img_attributes(html)
+      html.to_s
+        .gsub(/\s+srcset=(\"[^\"]*\"|'[^']*')/, "")
+        .gsub(/\s+sizes=(\"[^\"]*\"|'[^']*')/, "")
+    end
+
+    private
+
+    def rewrite_picture_tags_for_newsletter(markdown)
+      out = +""
+      lines = markdown.to_s.lines
+
+      i = 0
+      while i < lines.length
+        line = lines[i]
+
+        if line.lstrip.start_with?("{% picture")
+          tag = +""
+          loop do
+            tag << lines[i]
+            i += 1
+            break if tag.include?("%}") || i >= lines.length
+          end
+
+          out << transform_picture_tag(tag)
+          next
+        end
+
+        out << line
+        i += 1
+      end
+
+      out
+    end
+
+    def transform_picture_tag(tag)
+      m = tag.match(/\A(\s*)\{\%\s*picture\s+([\s\S]*?)\s*\%\}(\s*)\z/)
+      return tag unless m
+
+      leading_ws = m[1]
+      inner = m[2]
+      trailing_ws = m[3]
+
+      inner_lstripped = inner.lstrip
+
+      # If the tag doesn't already specify a preset, insert our newsletter preset.
+      if inner_lstripped.start_with?("/") || inner_lstripped.start_with?("./") || inner_lstripped.start_with?("../")
+        inner = "#{@preset} " + inner_lstripped
+      else
+        inner = inner_lstripped
+      end
+
+      # Remove `--img class="..."` (and single-quote variant).
+      inner = inner.gsub(/\s+--img\s+class=(\"[^\"]*\"|'[^']*')/, "")
+
+      "#{leading_ws}{% picture #{inner.rstrip} %}#{trailing_ws}"
+    end
+
+    def inject_frontmatter_image_picture_tag(markdown, image_field)
+      content = markdown.to_s
+
+      image_path, image_alt = extract_frontmatter_image(image_field)
+      return content if image_path.nil? || image_path.to_s.strip.empty?
+
+      image_path = normalize_image_path(image_path)
+
+      tag = +"{% picture #{image_path}"
+      if image_alt && !image_alt.to_s.strip.empty?
+        tag << %( --alt "#{escape_liquid_double_quotes(one_line(image_alt))}")
+      end
+      tag << " %}\n"
+
+      first_picture = first_picture_block(content)
+      return content if first_picture && first_picture.include?(image_path)
+
+      tag + "\n" + content
+    end
+
+    def first_picture_block(markdown)
+      lines = markdown.to_s.lines
+      i = 0
+      while i < lines.length
+        line = lines[i]
+        if line.strip.empty?
+          i += 1
+          next
+        end
+
+        return nil unless line.lstrip.start_with?("{% picture")
+
+        block = +""
+        loop do
+          block << lines[i]
+          i += 1
+          break if block.include?("%}") || i >= lines.length
+        end
+        return block
+      end
+      nil
+    end
+
+    def extract_frontmatter_image(image_field)
+      case image_field
+      when String
+        [image_field, nil]
+      when Hash
+        path = image_field["path"] || image_field[:path]
+        title = image_field["title"] || image_field[:title]
+        [path, title]
+      else
+        [nil, nil]
+      end
+    end
+
+    def normalize_image_path(path)
+      p = path.to_s.strip
+      return p if p.empty?
+      p = "/#{p}" unless p.start_with?("/", "./", "../")
+      p
+    end
+
+    def one_line(s)
+      s.to_s.gsub(/\s+/, " ").strip
+    end
+
+    def escape_liquid_double_quotes(s)
+      s.to_s.gsub("\\", "\\\\").gsub('"', '\"')
+    end
+  end
+end
+

--- a/jekyll_listmonk/lib/jekyll_listmonk/version.rb
+++ b/jekyll_listmonk/lib/jekyll_listmonk/version.rb
@@ -1,0 +1,4 @@
+module JekyllListmonk
+  VERSION = "0.1.0"
+end
+

--- a/lib/newsletter/jekyll_post_renderer.rb
+++ b/lib/newsletter/jekyll_post_renderer.rb
@@ -1,0 +1,96 @@
+module Newsletter
+  class JekyllPostRenderer
+    class Error < StandardError; end
+
+    def initialize(source_dir: Dir.pwd, jekyll_env: ENV.fetch("JEKYLL_ENV", "production"))
+      @source_dir = source_dir
+      @jekyll_env = jekyll_env
+    end
+
+    # identifier can be:
+    # - a slug like "instructions-beyond-code"
+    # - a post filename stem like "2024-03-07-instructions-beyond-code"
+    # - a path like "_posts/2024-03-07-instructions-beyond-code.md"
+    def render_post_fragment!(identifier)
+      require "jekyll"
+
+      ENV["JEKYLL_ENV"] = @jekyll_env
+
+      site = Jekyll::Site.new(Jekyll.configuration({ "source" => @source_dir, "quiet" => true }))
+      site.reset
+      site.read
+
+      doc = resolve_post!(site, identifier)
+
+      # Render without wrapping in the site's HTML layout (emails want fragments).
+      original_layout = doc.data["layout"]
+      doc.data["layout"] = nil
+
+      renderer = Jekyll::Renderer.new(site, doc)
+      html = renderer.run.to_s
+
+      doc.data["layout"] = original_layout
+
+      {
+        title: doc.data["title"].to_s,
+        description: doc.data["description"].to_s,
+        url: absolute_url_for(site, doc),
+        html: html
+      }
+    rescue LoadError => e
+      raise Error, "Jekyll not available: #{e.message}. Run with Bundler (e.g. bundle exec rake ...)."
+    end
+
+    private
+
+    def resolve_post!(site, identifier)
+      id = identifier.to_s.strip
+      raise Error, "Missing post identifier" if id.empty?
+
+      candidates = site.posts.docs
+
+      # If it looks like a path, match by relative path.
+      if id.include?("/") || id.end_with?(".md", ".markdown")
+        normalized = id.sub(%r{\A\./}, "")
+        match = candidates.find { |d| d.relative_path == normalized || d.path.end_with?(normalized) }
+        return match if match
+        raise Error, "No post matched path #{identifier.inspect}"
+      end
+
+      # Otherwise allow slug or filename-stem matching.
+      matches = candidates.select do |d|
+        stem = File.basename(d.path, ".*")
+        slug = stem.sub(/^\d{4}-\d{2}-\d{2}-/, "")
+        dslug = d.data["slug"].to_s
+
+        id == stem || id == slug || (!dslug.empty? && id == dslug) || stem.include?(id)
+      end
+
+      return matches.first if matches.size == 1
+
+      if matches.empty?
+        raise Error, "No post matched #{identifier.inspect}"
+      end
+
+      raise Error, "Ambiguous identifier #{identifier.inspect}. Matches: #{matches.map { |d| d.relative_path }.join(', ')}"
+    end
+
+    def absolute_url_for(site, doc)
+      base = site.config["url"].to_s
+      baseurl = site.config["baseurl"].to_s
+      path = doc.url.to_s
+
+      return path if base.empty?
+
+      base = base.sub(%r{/\z}, "")
+      baseurl = baseurl.sub(%r{\A/}, "").sub(%r{/\z}, "")
+      path = path.sub(%r{\A/}, "")
+
+      pieces = [base]
+      pieces << baseurl unless baseurl.empty?
+      pieces << path unless path.empty?
+      pieces.join("/")
+    end
+  end
+end
+

--- a/lib/newsletter/jekyll_post_renderer.rb
+++ b/lib/newsletter/jekyll_post_renderer.rb
@@ -31,6 +31,7 @@ module Newsletter
 
       renderer = Jekyll::Renderer.new(site, doc)
       html = renderer.run.to_s
+      html = strip_responsive_img_attributes(html)
 
       doc.data["layout"] = original_layout
       doc.content = original_content
@@ -99,6 +100,15 @@ module Newsletter
       inner = inner.gsub(/\s+--img\s+class=(\"[^\"]*\"|'[^']*')/, "")
 
       "#{leading_ws}{% picture #{inner.rstrip} %}#{trailing_ws}"
+    end
+
+    # Many email clients don't need (or want) responsive image attributes.
+    # If a picture tag renders to a single 640w image, jekyll_picture_tag still
+    # emits srcset="... 640w". For newsletters, strip srcset/sizes.
+    def strip_responsive_img_attributes(html)
+      html.to_s
+        .gsub(/\s+srcset=(\"[^\"]*\"|'[^']*')/, "")
+        .gsub(/\s+sizes=(\"[^\"]*\"|'[^']*')/, "")
     end
 
     def resolve_post!(site, identifier)

--- a/lib/newsletter/listmonk_client.rb
+++ b/lib/newsletter/listmonk_client.rb
@@ -1,0 +1,77 @@
+require "json"
+require "net/http"
+require "uri"
+
+module Newsletter
+  class ListmonkClient
+    class Error < StandardError; end
+
+    def initialize(base_url:, username: nil, password: nil, token: nil, timeout: 30)
+      @base_uri = URI(base_url)
+      @username = username
+      @password = password
+      @token = token
+      @timeout = timeout
+    end
+
+    def create_campaign!(
+      name:,
+      subject:,
+      lists:,
+      html_body:,
+      type: "regular",
+      from_email: nil,
+      from_name: nil,
+      tags: nil
+    )
+      payload = {
+        name: name,
+        subject: subject,
+        lists: lists,
+        type: type,
+        content_type: "html",
+        body: html_body
+      }
+
+      payload[:from_email] = from_email if from_email && !from_email.empty?
+      payload[:from_name] = from_name if from_name && !from_name.empty?
+      payload[:tags] = tags if tags && !tags.empty?
+
+      post_json!("/api/campaigns", payload)
+    end
+
+    private
+
+    def post_json!(path, payload)
+      uri = @base_uri.dup
+      uri.path = File.join(uri.path, path)
+
+      req = Net::HTTP::Post.new(uri)
+      req["Accept"] = "application/json"
+      req["Content-Type"] = "application/json"
+      req.body = JSON.dump(payload)
+
+      if @token && !@token.empty?
+        req["Authorization"] = "Bearer #{@token}"
+      elsif @username && @password
+        req.basic_auth(@username, @password)
+      end
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == "https")
+      http.open_timeout = @timeout
+      http.read_timeout = @timeout
+
+      res = http.request(req)
+      body = res.body.to_s
+
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "Listmonk API error (HTTP #{res.code}): #{body}"
+      end
+
+      JSON.parse(body)
+    rescue JSON::ParserError
+      raise Error, "Listmonk API returned non-JSON response (HTTP #{res&.code}): #{body}"
+    end
+  end
+end


### PR DESCRIPTION
Add Rake tasks to automate creating Listmonk newsletter campaigns from Jekyll posts.

This introduces `rake newsletter:preview` and `rake newsletter:campaign` to render Jekyll posts (including Liquid and Markdown) into email-friendly HTML and send them to the Listmonk API. This approach was chosen for complex, Ruby-heavy logic that leverages Jekyll's internal rendering pipeline, complementing the existing Makefile for site builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-899724e9-54c8-4dde-9e43-b1cddfe461e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-899724e9-54c8-4dde-9e43-b1cddfe461e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

