### PR TITLE
Image srcset sizing

### DIFF
--- a/_data/picture.yml
+++ b/_data/picture.yml
@@ -7,6 +7,10 @@ presets:
   default:
     formats: [jpg]
     widths: [400, 640, 800, 1280]
+
+  card:
+    formats: [jpg]
+    widths: [400, 640, 800, 1280]
     sizes:
       xl: 400px
       md: 320px

--- a/_data/picture.yml
+++ b/_data/picture.yml
@@ -1,7 +1,15 @@
+media_queries:
+  xl: 'min-width: 1200px'
+  md: 'min-width: 768px'
+
 presets:
   default:
     formats: [jpg]
     widths: [400, 640, 800, 1280]
+    sizes:
+      xl: 33vw
+      md: 50vw
+    size: 100vw
 
   feed:
     formats: [jpg]

--- a/_data/picture.yml
+++ b/_data/picture.yml
@@ -1,15 +1,17 @@
 media_queries:
   xl: 'min-width: 1200px'
   md: 'min-width: 768px'
+  sm: 'min-width: 400px'
 
 presets:
   default:
     formats: [jpg]
     widths: [400, 640, 800, 1280]
     sizes:
-      xl: 33vw
-      md: 50vw
-    size: 100vw
+      xl: 400px
+      md: 320px
+      sm: 400px
+    size: 200px
 
   feed:
     formats: [jpg]

--- a/_includes/cards.html
+++ b/_includes/cards.html
@@ -1,3 +1,4 @@
+{% assign card_sizes = include.sizes | default: "(min-width: 1200px) 33vw, (min-width: 768px) 50vw, 100vw" %}
 <div class="card-columns">
   {% for post in include.posts %}
   <div class="card-block">
@@ -5,7 +6,7 @@
     {% assign post_image = post.image.path | default: post.image %}
     {% if post_image %}
     {%- unless post_image contains "://" -%}
-    {% picture {{ post_image }} --alt {{ post.title | escape }} --img class="card-img-top" %}
+    {% picture {{ post_image }} --alt {{ post.title | escape }} --img class="card-img-top" sizes="{{ card_sizes }}" %}
     {% else %}
     <img class="card-img-top" alt="{{ post.title | escape }}" src="{{ post_image }}">
     {% endunless %}

--- a/_includes/cards.html
+++ b/_includes/cards.html
@@ -1,4 +1,3 @@
-{% assign card_sizes = include.sizes | default: "(min-width: 1200px) 33vw, (min-width: 768px) 50vw, 100vw" %}
 <div class="card-columns">
   {% for post in include.posts %}
   <div class="card-block">
@@ -6,7 +5,7 @@
     {% assign post_image = post.image.path | default: post.image %}
     {% if post_image %}
     {%- unless post_image contains "://" -%}
-    {% picture {{ post_image }} --alt {{ post.title | escape }} --img class="card-img-top" sizes="{{ card_sizes }}" %}
+    {% picture {{ post_image }} --alt {{ post.title | escape }} --img class="card-img-top" %}
     {% else %}
     <img class="card-img-top" alt="{{ post.title | escape }}" src="{{ post_image }}">
     {% endunless %}

--- a/_includes/cards.html
+++ b/_includes/cards.html
@@ -5,7 +5,7 @@
     {% assign post_image = post.image.path | default: post.image %}
     {% if post_image %}
     {%- unless post_image contains "://" -%}
-    {% picture {{ post_image }} --alt {{ post.title | escape }} --img class="card-img-top" %}
+    {% picture card {{ post_image }} --alt {{ post.title | escape }} --img class="card-img-top" %}
     {% else %}
     <img class="card-img-top" alt="{{ post.title | escape }}" src="{{ post_image }}">
     {% endunless %}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -3,5 +3,5 @@ layout: page
 ---
 
 <div class="card-columns-compact">
-{% include cards.html posts=page.posts sizes="(min-width: 768px) 33vw, 50vw" %}
+{% include cards.html posts=page.posts %}
 </div>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -3,5 +3,5 @@ layout: page
 ---
 
 <div class="card-columns-compact">
-{% include cards.html posts=page.posts %}
+{% include cards.html posts=page.posts sizes="(min-width: 768px) 33vw, 50vw" %}
 </div>


### PR DESCRIPTION
Add `sizes` attribute to `picture` tags to optimize image loading by matching displayed width.

Browsers without a `sizes` attribute assume images are 100vw, leading to larger images being loaded than necessary for multi-column layouts. This change provides accurate display width hints, significantly reducing bandwidth usage for images.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4a9f9ea-6d4f-4fac-8e88-4a858a0f4cc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4a9f9ea-6d4f-4fac-8e88-4a858a0f4cc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

