### PR TITLE
Content images height clamping

### DIFF
--- a/_scss/custom.scss
+++ b/_scss/custom.scss
@@ -394,15 +394,11 @@ header .navbar-nav .nav-link {
       }
     }
 
-    // Height clamping for content images (similar to .page-hero-image)
-    // Prevents portrait-oriented images from being too tall
-    // Min height matches landscape image width so both orientations have similar area
     p > img:not(.narrow):not(.wide),
     picture > img:not(.narrow):not(.wide) {
       @include media-breakpoint-up(sm) {
         height: auto;
         object-fit: contain;
-        // col-12 * 75% max-width ≈ 70vw
         max-height: min(50rem, max(70vw, 55svh));
       }
 
@@ -411,12 +407,10 @@ header .navbar-nav .nav-link {
       }
 
       @include media-breakpoint-up(lg) {
-        // col-10 * 75% max-width ≈ 55vw
         max-height: min(60rem, max(55vw, 65svh));
       }
 
       @include media-breakpoint-up(xl) {
-        // col-8 * 75% max-width ≈ 42vw
         max-height: min(65rem, max(42vw, 68svh));
       }
     }

--- a/_scss/custom.scss
+++ b/_scss/custom.scss
@@ -396,24 +396,28 @@ header .navbar-nav .nav-link {
 
     // Height clamping for content images (similar to .page-hero-image)
     // Prevents portrait-oriented images from being too tall
+    // Min height matches landscape image width so both orientations have similar area
     p > img:not(.narrow):not(.wide),
     picture > img:not(.narrow):not(.wide) {
       @include media-breakpoint-up(sm) {
         height: auto;
         object-fit: contain;
-        max-height: clamp(24rem, 55svh, 50rem);
+        // col-12 * 75% max-width ≈ 70vw
+        max-height: min(50rem, max(70vw, 55svh));
       }
 
       @include media-breakpoint-up(md) {
-        max-height: clamp(26rem, 60svh, 55rem);
+        max-height: min(55rem, max(70vw, 60svh));
       }
 
       @include media-breakpoint-up(lg) {
-        max-height: clamp(28rem, 65svh, 60rem);
+        // col-10 * 75% max-width ≈ 55vw
+        max-height: min(60rem, max(55vw, 65svh));
       }
 
       @include media-breakpoint-up(xl) {
-        max-height: clamp(28rem, 68svh, 65rem);
+        // col-8 * 75% max-width ≈ 42vw
+        max-height: min(65rem, max(42vw, 68svh));
       }
     }
 

--- a/_scss/custom.scss
+++ b/_scss/custom.scss
@@ -394,6 +394,29 @@ header .navbar-nav .nav-link {
       }
     }
 
+    // Height clamping for content images (similar to .page-hero-image)
+    // Prevents portrait-oriented images from being too tall
+    p > img:not(.narrow):not(.wide),
+    picture > img:not(.narrow):not(.wide) {
+      @include media-breakpoint-up(sm) {
+        height: auto;
+        object-fit: contain;
+        max-height: clamp(24rem, 55svh, 50rem);
+      }
+
+      @include media-breakpoint-up(md) {
+        max-height: clamp(26rem, 60svh, 55rem);
+      }
+
+      @include media-breakpoint-up(lg) {
+        max-height: clamp(28rem, 65svh, 60rem);
+      }
+
+      @include media-breakpoint-up(xl) {
+        max-height: clamp(28rem, 68svh, 65rem);
+      }
+    }
+
     picture {
       display: block;
       margin-bottom: 1rem;


### PR DESCRIPTION
Add height clamping to `.page-content` images to prevent overly tall portrait photos.

---
<a href="https://cursor.com/background-agent?bcId=bc-5824c5a9-54bd-481f-9561-1b8b5119c0ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5824c5a9-54bd-481f-9561-1b8b5119c0ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

